### PR TITLE
Add optional serialization using serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ edition = "2018"
 [dependencies]
 curl = "0.4.12"
 html5ever = "0.22.3"
+serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ let html = HTML::from_file("index.html", None);
 // or let html = HTML::from_string(input, None);
 ```
 
+## Serialization
+
+If you need to be able to serialize the data provided by the library using [serde](https://serde.rs/), you can include specify the `serde` *feature* while declaring your dependencies in `Cargo.toml`:
+
+```toml
+webpage = { version = "1.1", features = ["serde"] }
+```
+
 ## All fields
 
 ```rust

--- a/src/html.rs
+++ b/src/html.rs
@@ -14,6 +14,7 @@ use crate::parser::Parser;
 use crate::schema_org::SchemaOrg;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HTML {
     /// \<title\>
     pub title: Option<String>,

--- a/src/http.rs
+++ b/src/http.rs
@@ -5,6 +5,7 @@ use std::io;
 use std::time::Duration;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HTTP {
     /// The external ip address (v4 or v6)
     pub ip: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,13 @@ use std::io;
 use std::str;
 use std::time::Duration;
 
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+
 /// Resulting info for a webpage
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Webpage {
     /// info about the HTTP transfer
     pub http: HTTP,
@@ -80,6 +85,7 @@ pub struct Webpage {
 
 /// Configuration options
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WebpageOptions {
     /// Allow fetching over invalid and/or self signed HTTPS connections \[false\]
     pub allow_insecure: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ use std::str;
 use std::time::Duration;
 
 /// Resulting info for a webpage
+#[derive(Debug)]
 pub struct Webpage {
     /// info about the HTTP transfer
     pub http: HTTP,
@@ -78,6 +79,7 @@ pub struct Webpage {
 }
 
 /// Configuration options
+#[derive(Debug)]
 pub struct WebpageOptions {
     /// Allow fetching over invalid and/or self signed HTTPS connections \[false\]
     pub allow_insecure: bool,

--- a/src/opengraph.rs
+++ b/src/opengraph.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Representing [OpenGraph](http://ogp.me/) information
 pub struct Opengraph {
     /// Opengraph type (article, image, event, ..)
@@ -17,6 +18,7 @@ pub struct Opengraph {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Info about a media type
 pub struct OpengraphObject {
     /// URL describing this object

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -81,10 +81,10 @@ impl<'a> Parser<'a> {
 
 fn process_text(segment: Segment, tag_name: &str, contents: &str, html: &mut HTML) {
     if let Segment::Body = segment {
-        if tag_name != "style"
-            && tag_name != "script"
-            && tag_name != "noscript" {
-            html.text_content.push_str(" ");
+        if tag_name != "style" && tag_name != "script" && tag_name != "noscript" {
+            if !html.text_content.is_empty() {
+                html.text_content.push_str(" ");
+            }
             html.text_content.push_str(contents);
         }
     }

--- a/src/schema_org.rs
+++ b/src/schema_org.rs
@@ -42,13 +42,13 @@ mod tests {
     #[test]
     fn test_empty() {
         let schema = SchemaOrg::from("{}".to_string());
-        assert!(schema.is_none());
+        assert!(schema.is_empty());
     }
 
     #[test]
     fn test_type() {
         let schema = SchemaOrg::from("{\"@type\": \"article\"}".to_string());
-        assert!(schema.is_some());
-        assert_eq!(schema.unwrap().schema_type, "article");
+        assert_eq!(schema.len(), 1);
+        assert_eq!(schema[0].schema_type, "article");
     }
 }

--- a/src/schema_org.rs
+++ b/src/schema_org.rs
@@ -1,7 +1,8 @@
 use serde_json::{self, Value};
 
-#[derive(Debug)]
 /// Representing [Schema.org](https://schema.org/) information (currently only via JSON-LD)
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SchemaOrg {
     /// Schema.org type (article, image, event)
     pub schema_type: String,


### PR DESCRIPTION
This PR is intended to fix #4 by making all structs serializable using serde when the new `serde` feature is used in the dependency declaration.

It also adds `derive(Debug)` to `Webpage` and `WebpageOptions` (as they were missing) and fixes some tests and a small bug.
