### PR TITLE
feat: make curl and http optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,11 @@ authors = ["Otto <otto@ot-to.nl>"]
 repository = "https://github.com/orottier/webpage-rs"
 edition = "2018"
 
+[features]
+default = ["curl"]
+
 [dependencies]
-curl = "0.4.12"
+curl = { version = "0.4.12", optional = true }
 html5ever = "0.22.3"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = "1.0"

--- a/src/html.rs
+++ b/src/html.rs
@@ -13,7 +13,7 @@ use crate::opengraph::Opengraph;
 use crate::parser::Parser;
 use crate::schema_org::SchemaOrg;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HTML {
     /// \<title\>

--- a/src/http.rs
+++ b/src/http.rs
@@ -4,7 +4,7 @@ use curl::easy::Easy;
 use std::io;
 use std::time::Duration;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HTTP {
     /// The external ip address (v4 or v6)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //! ```
 
 pub mod html;
+#[cfg(feature = "curl")]
 pub mod http;
 pub mod opengraph;
 pub mod schema_org;
@@ -61,12 +62,12 @@ pub mod schema_org;
 mod parser;
 
 pub use crate::html::HTML;
+#[cfg(feature = "curl")]
 pub use crate::http::HTTP;
 pub use crate::opengraph::{Opengraph, OpengraphObject};
 pub use crate::schema_org::SchemaOrg;
 
-use std::io;
-use std::str;
+#[cfg(feature = "curl")]
 use std::time::Duration;
 
 #[cfg(feature = "serde")]
@@ -78,6 +79,7 @@ extern crate serde;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Webpage {
     /// info about the HTTP transfer
+    #[cfg(feature = "curl")]
     pub http: HTTP,
     /// info from the parsed HTML doc
     pub html: HTML,
@@ -85,6 +87,7 @@ pub struct Webpage {
 
 /// Configuration options
 #[derive(Debug)]
+#[cfg(feature = "curl")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WebpageOptions {
     /// Allow fetching over invalid and/or self signed HTTPS connections \[false\]
@@ -99,6 +102,7 @@ pub struct WebpageOptions {
     pub useragent: String,
 }
 
+#[cfg(feature = "curl")]
 impl Default for WebpageOptions {
     fn default() -> Self {
         Self {
@@ -111,6 +115,7 @@ impl Default for WebpageOptions {
     }
 }
 
+#[cfg(feature = "curl")]
 impl Webpage {
     /// Fetch a webpage from the given URL, and extract HTML info
     ///
@@ -121,7 +126,7 @@ impl Webpage {
     /// let info = Webpage::from_url("http://example.org", WebpageOptions::default());
     /// assert!(info.is_ok())
     /// ```
-    pub fn from_url(url: &str, options: WebpageOptions) -> Result<Self, io::Error> {
+    pub fn from_url(url: &str, options: WebpageOptions) -> Result<Self, std::io::Error> {
         let http = HTTP::fetch(url, options)?;
 
         let html = HTML::from_string(http.body.clone(), Some(http.url.clone()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,10 +76,10 @@ extern crate serde;
 
 /// Resulting info for a webpage
 #[derive(Debug)]
+#[cfg(feature = "curl")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Webpage {
     /// info about the HTTP transfer
-    #[cfg(feature = "curl")]
     pub http: HTTP,
     /// info from the parsed HTML doc
     pub html: HTML,

--- a/src/opengraph.rs
+++ b/src/opengraph.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Representing [OpenGraph](http://ogp.me/) information
 pub struct Opengraph {
@@ -17,7 +17,7 @@ pub struct Opengraph {
     pub audios: Vec<OpengraphObject>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Info about a media type
 pub struct OpengraphObject {

--- a/src/schema_org.rs
+++ b/src/schema_org.rs
@@ -1,7 +1,7 @@
 use serde_json::{self, Value};
 
 /// Representing [Schema.org](https://schema.org/) information (currently only via JSON-LD)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SchemaOrg {
     /// Schema.org type (article, image, event)


### PR DESCRIPTION
This allows users to not pull in `curl` as a dependency if they don't need it.