### PR TITLE
Update html5ever and markup5ever_rcdom dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = ["curl"]
 
 [dependencies]
 curl = { version = "0.4.41", optional = true }
-html5ever = "0.25.1"
-markup5ever_rcdom = "0.1.0"
+html5ever = "0.26.0"
+markup5ever_rcdom = "0.2.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Current rustc versions are warning about future incompatibilities of xml5ever v0.16.2, which is a dependency of markup5ever_rcdom. This incompatibility has already been fixed in newer versions.