### PR TITLE
feat: allow custom request headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ html5ever = "0.26.0"
 markup5ever_rcdom = "0.2.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["full", "macros"] }
+wiremock = "0.5"

--- a/src/http.rs
+++ b/src/http.rs
@@ -51,6 +51,7 @@ impl HTTP {
         handle.follow_location(options.follow_location)?;
         handle.max_redirections(options.max_redirections)?;
         handle.useragent(&options.useragent)?;
+        handle.http_headers(options.headers)?;
 
         handle.url(url)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub use crate::schema_org::SchemaOrg;
 
 #[cfg(feature = "curl")]
 use std::time::Duration;
+use curl::easy::List;
 
 #[cfg(feature = "serde")]
 #[macro_use]
@@ -100,6 +101,8 @@ pub struct WebpageOptions {
     pub timeout: Duration,
     /// User agent string used for the request \[webpage-rs - <https://crates.io/crates/webpage>\]
     pub useragent: String,
+    /// Custom HTTP headers to send with the request
+    #[non_exhaustive] pub headers: List,
 }
 
 #[cfg(feature = "curl")]
@@ -111,6 +114,7 @@ impl Default for WebpageOptions {
             max_redirections: 5,
             timeout: Duration::from_secs(10),
             useragent: "webpage-rs - https://crates.io/crates/webpage".to_string(),
+            headers: List::new(),
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,6 +2,9 @@ extern crate webpage;
 
 #[cfg(feature = "curl")]
 use webpage::{html::HTML, Webpage, WebpageOptions};
+use curl::easy::List;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::matchers::{header, method};
 
 #[test]
 fn from_file() {
@@ -25,4 +28,67 @@ fn from_url() {
     let html = webpage.unwrap().html;
     assert_eq!(html.title, Some("Example Domain".to_string()));
     assert!(html.description.is_none());
+}
+
+#[tokio::test]
+#[cfg(feature = "curl")]
+async fn from_url_with_title() {
+    let mock_server = MockServer::start().await;
+    let response_template = ResponseTemplate::new(200)
+        .set_body_string("<html><head><title>testing</title></head><body></body></html>");
+    Mock::given(method("GET"))
+        .respond_with(response_template)
+        .up_to_n_times(1)
+        .expect(1)
+        .named("from_url_with_title GET")
+        .mount(&mock_server)
+        .await;
+
+    let webpage = Webpage::from_url(&mock_server.uri(), WebpageOptions::default());
+    assert!(webpage.is_ok());
+
+    let html = webpage.unwrap().html;
+    assert_eq!(html.title, Some("testing".to_string()));
+    assert!(html.description.is_none());
+}
+
+#[tokio::test]
+#[cfg(feature = "curl")]
+async fn from_url_with_headers() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(header("X-My-Header", "1234"))
+        .respond_with(ResponseTemplate::new(200))
+        .up_to_n_times(1)
+        // We expect the mock to be called exactly once.
+        .expect(1)
+        // We assign a name to the mock - it will be shown in error messages
+        // if our expectation is not verified!
+        .named("from_url_with_headers GET")
+        .mount(&mock_server)
+        .await;
+
+    let custom_header = "X-My-Header: 1234";
+    let mut my_headers = List::new();
+    my_headers.append(custom_header).unwrap();
+    let options = WebpageOptions { headers: my_headers, ..Default::default() };
+    let url = &mock_server.uri();
+    let webpage = Webpage::from_url(url, options);
+    assert!(webpage.is_ok());
+}
+
+#[tokio::test]
+#[cfg(feature = "curl")]
+async fn from_url_without_headers() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200))
+        .up_to_n_times(1)
+        .expect(1)
+        .named("from_url_without_headers GET")
+        .mount(&mock_server)
+        .await;
+
+    let webpage = Webpage::from_url(&mock_server.uri(), WebpageOptions::default());
+    assert!(webpage.is_ok());
 }


### PR DESCRIPTION
This change allows custom request headers to be added.

I've also introduced two `dev-dependencies`: 

1. tokio
2. wiremock

This allows the server to be mocked and verify the request headers are sent.

Closes #15 